### PR TITLE
Compatibility with esqueleto 4

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,7 @@
+packages:
+    .
+
+source-repository-package
+    type: git
+    location: https://github.com/bitemyapp/esqueleto
+    tag: 1c386787cb4caca69ffa0d8073b64aad47d5a366

--- a/esqueleto-compat.cabal
+++ b/esqueleto-compat.cabal
@@ -27,6 +27,9 @@ library
     Database.Esqueleto.Compat.Operators
     Database.Esqueleto.Compat.Suffixed
 
+  other-modules:
+    Import.Database.Esqueleto
+
   build-depends:
       base              >= 4.13 && < 5
     , persistent
@@ -78,5 +81,6 @@ test-suite esqueleto-compat-test
   build-depends:
       base >=4.7 && <5
     , esqueleto-compat
+    , persistent
     , hspec
   default-language: Haskell2010

--- a/esqueleto-compat.cabal
+++ b/esqueleto-compat.cabal
@@ -5,9 +5,9 @@ version:        0.0.2.0
 description:    Please see the README on GitHub at <https://github.com/parsonsmatt/esqueleto-compat#readme>
 homepage:       https://github.com/parsonsmatt/esqueleto-compat#readme
 bug-reports:    https://github.com/parsonsmatt/esqueleto-compat/issues
-author:         Matt von Hagen
+author:         Matt Parsons
 maintainer:     parsonsmatt@gmail.com
-copyright:      2023 Matt von Hagen
+copyright:      2023 Matt Parsons
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple

--- a/esqueleto-compat.cabal
+++ b/esqueleto-compat.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           esqueleto-compat
-version:        0.0.2.0
+version:        0.0.2.1
 description:    Please see the README on GitHub at <https://github.com/parsonsmatt/esqueleto-compat#readme>
 homepage:       https://github.com/parsonsmatt/esqueleto-compat#readme
 bug-reports:    https://github.com/parsonsmatt/esqueleto-compat/issues

--- a/src/Database/Esqueleto/Compat.hs
+++ b/src/Database/Esqueleto/Compat.hs
@@ -11,13 +11,14 @@
 module Database.Esqueleto.Compat
     ( -- * The compatibility operators
       module Database.Esqueleto.Compat.Operators
-    , -- * Re-exports from "Database.Esqueleto.Experimental"
-        module Database.Esqueleto.Experimental
+    , module Database.Esqueleto.Compat.Suffixed
+    , -- * Re-exports from "Database.Esqueleto.Experimental" (or "Database.Esqueleto" in esqueleto >= 4)
+        module Import.Database.Esqueleto
       -- * Re-exports from "Database.Persist.Sql"
     , module Database.Persist.Sql
     ) where
 
-import Database.Esqueleto.Experimental hiding
+import Import.Database.Esqueleto hiding
     ( not_
     , update
     , selectSource

--- a/src/Database/Esqueleto/Compat/Operators.hs
+++ b/src/Database/Esqueleto/Compat/Operators.hs
@@ -1,7 +1,9 @@
+-- | This module exposes a set of operators that are capable of being used
+-- both in a @persistent@ context and an @esqueleto@ context.
 module Database.Esqueleto.Compat.Operators where
 
-import Database.Esqueleto.Experimental (SqlExpr, Value)
-import qualified Database.Esqueleto.Experimental as Esqueleto
+import Import.Database.Esqueleto (SqlExpr, SqlExpr_, Value)
+import qualified Import.Database.Esqueleto as Esqueleto
 import qualified Database.Esqueleto.Internal.Internal as Esqueleto
 import Database.Persist.Sql (Entity, EntityField, PersistEntity, PersistField, Filter)
 import qualified Database.Persist.Sql as Persist
@@ -31,8 +33,10 @@ instance
   (*=.) = (Persist.*=.)
 
 instance
-  (PersistEntity rec, PersistField typ, field ~ EntityField rec typ) =>
-  SqlAssignment field (SqlExpr (Value typ)) (SqlExpr (Entity rec) -> SqlExpr Esqueleto.Update)
+  ( PersistEntity rec, PersistField typ, field ~ EntityField rec typ
+  , ctx0 ~ Esqueleto.ValueContext, ctx1 ~ ctx0, ctx2 ~ ctx1)
+  =>
+  SqlAssignment field (SqlExpr_ ctx0 (Value typ)) (SqlExpr_ ctx1 (Entity rec) -> SqlExpr_ ctx2 Esqueleto.Update)
   where
   (=.) = (Esqueleto.=.)
   (-=.) = (Esqueleto.-=.)
@@ -135,15 +139,18 @@ instance
   (<=.) = (Persist.<=.)
 
 instance
-  (PersistField a, a ~ b, lhs ~ SqlExpr (Value a), c ~ Bool) =>
-  SqlComparison (SqlExpr (Value a)) (SqlExpr (Value b)) (SqlExpr (Value c))
+    ( PersistField a, a ~ b, lhs ~ SqlExpr (Value a), c ~ Bool
+    , ctx0 ~ ctx1, ctx1 ~ ctx2
+    )
+  =>
+    SqlComparison (SqlExpr_ ctx0 (Value a)) (SqlExpr_ ctx1 (Value b)) (SqlExpr_ ctx2 (Value c))
   where
-  (==.) = (Esqueleto.==.)
-  (!=.) = (Esqueleto.!=.)
-  (>.) = (Esqueleto.>.)
-  (>=.) = (Esqueleto.>=.)
-  (<.) = (Esqueleto.<.)
-  (<=.) = (Esqueleto.<=.)
+    (==.) = (Esqueleto.==.)
+    (!=.) = (Esqueleto.!=.)
+    (>.) = (Esqueleto.>.)
+    (>=.) = (Esqueleto.>=.)
+    (<.) = (Esqueleto.<.)
+    (<=.) = (Esqueleto.<=.)
 
 -- | An alias for '!=.', in keeping with the convention of having Haskell-ish
 -- operators.

--- a/src/Database/Esqueleto/Compat/Suffixed.hs
+++ b/src/Database/Esqueleto/Compat/Suffixed.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- | This module defines new names for terms in @esqueleto@ that have
 -- common conflicts with other modules.
 --
@@ -6,11 +8,14 @@
 --
 -- Functions that are about manipulating 'SqlExpr' are suffixed with an
 -- @_@. So @isNothing@ becomes 'isNothing_'.
-module Database.Esqueleto.Compat.Suffixed where
+module Database.Esqueleto.Compat.Suffixed
+    ( module Database.Esqueleto.Compat.Suffixed
+    , isNothing_
+    ) where
 
-import qualified Database.Esqueleto.Experimental as E
 import Database.Esqueleto.Internal.Internal
-import Database.Esqueleto.Experimental
+import qualified Import.Database.Esqueleto as E
+import Import.Database.Esqueleto
     ( SqlExpr
     , Entity, SqlQuery, PersistEntity, BackendCompatible, SqlBackend
     , PersistEntityBackend
@@ -60,8 +65,12 @@ deleteE = E.delete
 count_ :: (Num a) => SqlExpr (Value typ) -> SqlExpr (Value a)
 count_ = E.count
 
-groupBy_ :: (ToSomeValues a) => a -> SqlQuery ()
-groupBy_ = E.groupBy
+#if MIN_VERSION_esqueleto(3,5,10)
 
+#else
 isNothing_ :: (E.PersistField a) => SqlExpr (Value (Maybe a)) -> SqlExpr (Value Bool)
 isNothing_ = E.isNothing
+
+groupBy_ :: (ToSomeValues a) => a -> SqlQuery ()
+groupBy_ = E.groupBy
+#endif

--- a/src/Import/Database/Esqueleto.hs
+++ b/src/Import/Database/Esqueleto.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE CPP #-}
+
+-- | This module carries the imports for "Database.Esqueleto.Experimental"
+-- in a manner that avoids the warnings and deprecations present with
+-- 0.4.0.0.
+module Import.Database.Esqueleto
+    ( module X
+    , SqlExpr_
+    , ValueContext
+    ) where
+
+#if MIN_VERSION_esqueleto(4,0,0)
+import Database.Esqueleto as X
+import Database.Esqueleto.Internal.Internal (SqlExpr_, ValueContext)
+#else
+import Database.Esqueleto.Experimental as X
+#endif
+
+#if MIN_VERSION_esqueleto(4,0,0)
+
+#else
+-- | @esqueleto@ version 4 modified the 'SqlExpr' type to carry a context
+-- type variable.
+--
+-- @
+-- data SqlExpr_ context val
+--
+-- data ValueContext
+-- data AggregateContext
+--
+-- type SqlExpr = SqlExpr_ ValueContext
+-- @
+--
+-- We provide this type alias as a means of giving backwards compatibility
+-- in the library - it should still build and test fine with @esqueleto
+-- < 4@ while also supporting the additional polymorphism in @esqueleto >=
+-- 4@.
+type SqlExpr_ ignore = SqlExpr
+
+-- | A dummy type to be thrown away by 'SqlExpr_'
+data ValueContext
+#endif

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,5 +1,157 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+
 {-# options_ghc -Wall #-}
 module Main where
 
+import Database.Esqueleto.Compat
+import Database.Persist.TH
+import Test.Hspec
+
+mkPersist sqlSettings [persistLowerCase|
+
+    User
+        name    String
+        age     Int
+
+    Post
+        author  UserId
+        title   String
+
+    Comment
+        author  UserId
+        post    PostId
+        body    String
+    |]
+
 main :: IO ()
-main = putStrLn "no tests yet boss"
+main = hspec spec
+
+typechecks :: a -> IO ()
+typechecks _ = pure ()
+
+userTable :: SqlExpr (Entity User)
+userTable = undefined
+
+postTable :: SqlExpr (Entity Post)
+postTable = undefined
+
+commentTable :: SqlExpr (Entity Comment)
+commentTable = undefined
+
+spec :: Spec
+spec = do
+    sqlComparisonSpec
+    sqlAssignmentSpec
+
+sqlComparisonSpec :: Spec
+sqlComparisonSpec = describe "SqlComparison" $ do
+    describe "Persistent" $ do
+        it "works with EntityField" $ do
+            typechecks @(SqlPersistT IO _) $ do
+                selectList [UserName ==. "hello"] []
+
+        it "works with overloaded label" $ do
+            typechecks @(SqlPersistT IO [Entity User]) $ do
+                selectList [#name ==. "hello"] []
+
+        it "works with polymorphic literal" $ do
+            typechecks @(SqlPersistT IO _) $ do
+                selectList [UserAge ==. 1] []
+
+        it "works with literal and symbol" $ do
+            typechecks @(SqlPersistT IO [Entity User]) $ do
+                selectList [#age ==. 1] []
+
+    describe "Esqueleto" $ do
+        describe "comparing two tables" $ do
+            it "works when typed in esqueleto context" $ do
+                typechecks $ do
+                    userTable ^. UserName ==. postTable ^. PostTitle
+            it "works when using symbol to field" $ do
+                typechecks $ do
+                    userTable ^. #name ==. postTable ^. #title
+
+            it "works when using overloaded record dot" $ do
+                typechecks $ do
+                    userTable.name ==. postTable.title
+
+        describe "with val" $ do
+            it "type inference works" $ do
+                typechecks $ do
+                    userTable ^. UserName ==. val "hello"
+            it "even with polymorphic val" $ do
+                typechecks $ do
+                    userTable ^. UserAge ==. val 1
+            it "with symbol to field" $ do
+                typechecks $ do
+                    userTable ^. #age ==. val 1
+            it "with overloaded record dot" $ do
+                typechecks $ do
+                    userTable.age ==. val 1
+
+        describe "with from" $ do
+            it "infers with explicit table annotation" $ do
+                typechecks $ do
+                    u <- from $ table @User
+                    where_ $ u.name ==. val "hello"
+                    pure u
+
+            it "infers with explicit field use" $ do
+                typechecks $ do
+                    u <- from table
+                    where_ $ u ^. UserName ==. val "hello"
+                    pure u
+
+            it "infers with symbol to field" $ do
+                typechecks $ do
+                    u <- from $ table @User
+                    where_ $ u ^. #name ==. val "hello"
+                    pure u
+
+            it "joins aren't painful" $ do
+                typechecks $ do
+                    u :& p :& c <-
+                        from $
+                            table @User
+                                `innerJoin` table @Post
+                                    `on` do
+                                        \(u :& p) ->
+                                            u.id ==. p.author
+                                `innerJoin` table @Comment
+                                    `on` do
+                                        \(_ :& p :& c) ->
+                                            p.id ==. c.post
+                    where_ $ u.name ==. val "hello"
+                    where_ $ p.title ==. val "asdf"
+                    where_ $ c.body ==. val "no"
+                    pure (u :& c)
+
+sqlAssignmentSpec :: Spec
+sqlAssignmentSpec = describe "SqlAssignment" $ do
+    describe "Esqueleto" $ do
+        it "works with explicit field" $ do
+            typechecks @(SqlPersistT IO _) $ do
+                updateE $ \user -> do
+                    set user [UserAge =. val 10]
+        it "works with symbol, as long as user is inferred" $ do
+            typechecks @(SqlPersistT IO _) $ do
+                updateE $ \user -> do
+                    set user [#age =. val 10]
+                    where_ $ user ^. UserName ==. val "hello"
+
+    describe "Persistent" $ do
+        pure ()


### PR DESCRIPTION
`esqueleto-4` is going to introduce some changes to `SqlExpr` type. These changes break type inference when people are using the library. As a result, I have pushed a Hackage revision to only support `esqueleto < 4` in the current Hackage release of this package.

This PR intends to provide backwards compatibility - working with `esqueleto < 4` and `esqueleto >= 4` transparently.

Before submitting your PR, check that you've:

- [ ] Bumped the version number.
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [ ] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
